### PR TITLE
fix page.enable message issue for arm64 crash

### DIFF
--- a/nodriver/core/connection.py
+++ b/nodriver/core/connection.py
@@ -88,6 +88,8 @@ class Transaction(asyncio.Future):
 
     @property
     def message(self):
+        if self.method == "Page.enable":
+            return json.dumps({"method": self.method, "id": self.id})
 
         return json.dumps({"method": self.method, "params": self.params, "id": self.id})
 


### PR DESCRIPTION
according to the specs of chrome devtools protocol the page.enable should not have any arguments passed. On an arm64 machine this caused crashed:

https://chromedevtools.github.io/devtools-protocol/1-3/Page/#method-enable