### PR TITLE
Destroy browser instance on stop

### DIFF
--- a/nodriver/core/browser.py
+++ b/nodriver/core/browser.py
@@ -624,6 +624,8 @@ class Browser:
                         raise
             self._process = None
             self._process_pid = None
+            util.get_registered_instances().remove(self)
+            util.deconstruct_browser(self)
 
     def __await__(self):
         # return ( asyncio.sleep(0)).__await__()
@@ -848,4 +850,4 @@ class HTTPApi:
         return json.loads(response.read())
 
 
-atexit.register(util.deconstruct_browser)
+atexit.register(util.deconstruct_browsers)

--- a/nodriver/core/util.py
+++ b/nodriver/core/util.py
@@ -146,30 +146,37 @@ def free_port() -> int:
     free_socket.close()
     return port
 
-
-def deconstruct_browser():
+def deconstruct_browser(browser: Browser):
     import time
 
-    for _ in __registered__instances__:
-        if not _.stopped:
-            _.stop()
-        for attempt in range(5):
-            try:
-                if _.config and not _.config.uses_custom_data_dir:
-                    shutil.rmtree(_.config.user_data_dir, ignore_errors=False)
-            except FileNotFoundError as e:
+    if not browser.stopped:
+        browser.stop()
+    
+    for attempt in range(5):
+        try:
+            if browser.config and not browser.config.uses_custom_data_dir:
+                shutil.rmtree(browser.config.user_data_dir, ignore_errors=False)
+        except FileNotFoundError as e:
+            break
+        except (PermissionError, OSError) as e:
+            if attempt == 4:
+                logger.debug(
+                    "problem removing data dir %s\nConsider checking whether it's there and remove it by hand\nerror: %s",
+                    browser.config.user_data_dir,
+                    e,
+                )
                 break
-            except (PermissionError, OSError) as e:
-                if attempt == 4:
-                    logger.debug(
-                        "problem removing data dir %s\nConsider checking whether it's there and remove it by hand\nerror: %s",
-                        _.config.user_data_dir,
-                        e,
-                    )
-                    break
-                time.sleep(0.15)
-                continue
-        print("successfully removed temp profile %s" % _.config.user_data_dir)
+            time.sleep(0.15)
+            continue
+    
+    print("successfully removed temp profile %s" % browser.config.user_data_dir)
+
+
+def deconstruct_browsers():
+    for _ in __registered__instances__:
+        deconstruct_browser(_)
+    
+    __registered__instances__.clear()
 
 
 def filter_recurse_all(

--- a/nodriver/core/util.py
+++ b/nodriver/core/util.py
@@ -169,7 +169,7 @@ def deconstruct_browser(browser: Browser):
             time.sleep(0.15)
             continue
     
-    print("successfully removed temp profile %s" % browser.config.user_data_dir)
+    logger.info("successfully removed temp profile %s" % browser.config.user_data_dir)
 
 
 def deconstruct_browsers():


### PR DESCRIPTION
Xilriws often recreates new browser instances with the default tmp directory generation, those files will fill up disk space overtime up to a few gigabytes.

This PR will remove browser instances from the ``__registered__instances__`` Set automatically on stop and then properly remove the temporary directory used on stop instead of on exit.